### PR TITLE
Spark Maker: add support for drag-and-drop

### DIFF
--- a/css/spark.css
+++ b/css/spark.css
@@ -166,6 +166,7 @@ td {
     position: fixed !important;
     pointer-events: none;
     z-index: 9999;
+	opacity: 50%;
     left: 0;
     top: 0;
     will-change: transform; 

--- a/css/spark.css
+++ b/css/spark.css
@@ -6,6 +6,15 @@
 	padding: 5px;
 	margin: 10px auto;
 	position: relative;
+	/* disable selection for performance */
+	user-select: none;
+    -webkit-user-select: none;
+	touch-action: none;
+}
+
+.spark-disable-interactions {
+	/* Add this class during dragging for performance */
+	pointer-events: none !important;
 }
 
 .spark-manual {
@@ -36,6 +45,8 @@
 .spark-image {
 	max-height: 80px;
 	box-sizing: border-box;
+	content-visibility: auto-pointer-events; 
+    contain-intrinsic-size: 80px;
 }
 
 #spark-main {
@@ -136,6 +147,7 @@ td {
 	width: 100%;
 	height: calc((100% - 52px * 2)* 0.25);
 	overflow-y: scroll;
+	contain: strict;
 }
 
 .spark-result {
@@ -294,6 +306,7 @@ td {
 		
 		.spark-image {
 			max-height: 60px;
+			contain-intrinsic-size: 60px;
 		}
 
 		.spark-ui-element {

--- a/css/spark.css
+++ b/css/spark.css
@@ -145,6 +145,8 @@ td {
 	margin: 0px;
 	box-sizing: border-box;
 	position: relative;
+	-webkit-animation: spark-img-fadein .5s;
+	animation: spark-img-fadein .5s;
 }
 
 .spark-result-img {
@@ -153,8 +155,6 @@ td {
 	min-height: 100%;
 	max-width: 100%;
 	max-height: 100%;
-	-webkit-animation: spark-img-fadein .5s;
-	animation: spark-img-fadein .5s;
 }
 
 .sparked {

--- a/css/spark.css
+++ b/css/spark.css
@@ -150,6 +150,7 @@ td {
 }
 
 .spark-result.placeholder {
+	z-index: -1;
 	opacity: 50%;
 	-webkit-animation-duration: spark-img-fadein .5s;
 	animation-duration: 0s;

--- a/css/spark.css
+++ b/css/spark.css
@@ -12,11 +12,6 @@
 	touch-action: none;
 }
 
-.spark-disable-interactions {
-	/* Add this class during dragging for performance */
-	pointer-events: none !important;
-}
-
 .spark-manual {
 	background: #181818;
 	color: #ffffff;
@@ -159,6 +154,17 @@ td {
 	position: relative;
 	-webkit-animation: spark-img-fadein .5s;
 	animation: spark-img-fadein .5s;
+}
+
+.spark-drag-ghost {
+	width: 105px;
+	height: 60px;
+    position: fixed !important;
+    pointer-events: none;
+    z-index: 9999;
+    left: 0;
+    top: 0;
+    will-change: transform; 
 }
 
 .spark-result.placeholder {

--- a/css/spark.css
+++ b/css/spark.css
@@ -151,6 +151,8 @@ td {
 
 .spark-result.placeholder {
 	opacity: 50%;
+	-webkit-animation-duration: spark-img-fadein .5s;
+	animation-duration: 0s;
 }
 
 .spark-result-img {

--- a/css/spark.css
+++ b/css/spark.css
@@ -42,6 +42,9 @@
 	box-sizing: border-box;
 	content-visibility: auto-pointer-events; 
     contain-intrinsic-size: 80px;
+	/* related to dragging feature */
+	touch-action: pan-y;
+    -webkit-user-drag: none;
 }
 
 #spark-main {

--- a/css/spark.css
+++ b/css/spark.css
@@ -149,6 +149,10 @@ td {
 	animation: spark-img-fadein .5s;
 }
 
+.spark-result.placeholder {
+	opacity: 50%;
+}
+
 .spark-result-img {
 	display: block;
 	min-width: 100%;

--- a/css/spark.css
+++ b/css/spark.css
@@ -145,6 +145,7 @@ td {
 .spark-select {
 	width: 100%;
 	height: calc((100% - 52px * 2)* 0.25);
+	overflow-x: hidden;
 	overflow-y: scroll;
 	contain: strict;
 }

--- a/css/spark.css
+++ b/css/spark.css
@@ -79,6 +79,14 @@ td {
 	line-height: 0;
 	padding-top: 2px;
 	padding-bottom: 2px;
+	border-width: 2px;
+	border-style: solid;
+	border-color: transparent;
+	border-radius: 5px;
+}
+
+.spark-section-highlight {
+	border-color: #ffffff;
 }
 
 .spark-ui-container {

--- a/css/spark.css
+++ b/css/spark.css
@@ -9,7 +9,6 @@
 	/* disable selection for performance */
 	user-select: none;
     -webkit-user-select: none;
-	touch-action: none;
 }
 
 .spark-manual {
@@ -162,6 +161,7 @@ td {
 	position: relative;
 	-webkit-animation: spark-img-fadein .5s;
 	animation: spark-img-fadein .5s;
+	touch-action: none;
 }
 
 .spark-drag-ghost {

--- a/css/spark.css
+++ b/css/spark.css
@@ -92,7 +92,11 @@ td {
 }
 
 .spark-section-highlight {
-	border-color: #ffffff;
+	background-color: #0000ff0d;
+}
+
+.spark-section-highlight-enabled {
+	background-color: #00ff000d;
 }
 
 .spark-ui-container {

--- a/css/spark.css
+++ b/css/spark.css
@@ -168,7 +168,6 @@ td {
 }
 
 .spark-result.placeholder {
-	z-index: -1;
 	opacity: 50%;
 	-webkit-animation-duration: spark-img-fadein .5s;
 	animation-duration: 0s;

--- a/js/spark.js
+++ b/js/spark.js
@@ -451,7 +451,18 @@ function is_valid_drag_event(event)
 
 function find_position(section, event)
 {
-	return 0; // hard-coded for now
+	const children = section.children;
+	let position = 0;
+	for(let i = 0; i < children.length; ++i)
+	{
+		const rect = children[i].getBoundingClientRect();
+		if(event.clientY < rect.top)
+			break;
+		else if(event.clientY < rect.bottom && event.clientX < rect.left)
+			break;
+		position = i;
+	}
+	return position;
 }
 
 function update_drag_state(event)

--- a/js/spark.js
+++ b/js/spark.js
@@ -118,11 +118,10 @@ function is_summon(cid)
 	return cid.startsWith("20");
 }
 
-function is_valid_mode(cid, mode)
+function is_valid_mode(cid, mode, gbtype)
 {
-	const isSummon = is_summon(drag_id);
-	if(isSummon && mode != STONE) return false;
-	if(!isSummon && mode == STONE) return false;
+	if(gbtype == GBFType.summon && mode != STONE) return false;
+	if(gbtype != GBFType.summon && mode == STONE) return false;
 	return true;
 }
 
@@ -141,7 +140,7 @@ function set_spark_list()
 			const ret = get_character(id, null, [-1, -1, -1, -1, 0, 1000]);
 			if(ret != null)
 			{
-				items[id] = add_image_spark(frag, ret[0]); // display and memorize in items
+				items[id] = add_image_spark(frag, ret[0], GBFType.character); // display and memorize in items
 			}
 		}
 	}
@@ -151,7 +150,7 @@ function set_spark_list()
 		const ret = get_character(id, (index["characters"][id] !== 0 ? index["characters"][id] : null), [-1, -1, -1, -1, 0, 1000]);
 		if(ret != null)
 		{
-			items[id] = add_image_spark(frag, ret[0]); // display and memorize in items
+			items[id] = add_image_spark(frag, ret[0], GBFType.character); // display and memorize in items
 		}
 	}
 	node.appendChild(frag);
@@ -169,7 +168,7 @@ function set_spark_list()
 			const ret = get_summon(id, null, "4", [0, 1000]);
 			if(ret != null)
 			{
-				items[id] = add_image_spark(frag, ret[0]); // display and memorize in items
+				items[id] = add_image_spark(frag, ret[0], GBFType.summon); // display and memorize in items
 			}
 		}
 	}
@@ -179,17 +178,18 @@ function set_spark_list()
 		const ret = get_summon(id, (index["summons"][id] !== 0 ? index["summons"][id] : null), "4", [0, 1000]);
 		if(ret != null)
 		{
-			items[id] = add_image_spark(frag, ret[0]); // display and memorize in items
+			items[id] = add_image_spark(frag, ret[0], GBFType.summon); // display and memorize in items
 		}
 	}
 	node.appendChild(frag);
 }
 
-function add_image_spark(node, data) // add an image to the selector
+function add_image_spark(node, data, gbtype) // add an image to the selector
 {
 	let img = document.createElement("img");
 	img.title = data.id;
 	img.dataset.id = data.id;
+	img.gbtype = gbtype;
 	img.classList.add("loading");
 	img.classList.add("spark-image");
 	img.setAttribute('loading', 'lazy');
@@ -200,7 +200,6 @@ function add_image_spark(node, data) // add an image to the selector
 		};
 	}
 	else img.onerror = data.onerr;
-	const isSummon = is_summon(data.id);
 	const cid = data.id;
 	img.onload = function() {
 		this.classList.remove("loading");
@@ -215,13 +214,13 @@ function add_image_spark(node, data) // add an image to the selector
 			{
 				canvas = null;
 				beep();
-				if(!isSummon && (window.event.shiftKey || document.getElementById("moon-check").classList.contains("active"))) // add to moon
+				if(this.gbtype == GBFType.character && (window.event.shiftKey || document.getElementById("moon-check").classList.contains("active"))) // add to moon
 				{
 					add_image_result_spark(MOON, cid, this);
 				}
 				else
 				{
-					add_image_result_spark(isSummon ? STONE : NPC, cid, this); // add to npc or stone
+					add_image_result_spark(this.gbtype == GBFType.summon ? STONE : NPC, cid, this); // add to npc or stone
 				}
 				document.getElementById("spark-container").scrollIntoView(); // recenter view
 				spark_save_settings();
@@ -485,7 +484,7 @@ function update_drag_state(event)
 		remove_image_result_spark(drag_placeholder_div);
 		drag_placeholder_div = null;
 	}
-	if(is_valid_mode(drag_id, mode))
+	if(is_valid_mode(drag_id, mode, items[drag_id].gbtype))
 	{
 		const img = items[drag_id];
 		if(!img) return;
@@ -544,7 +543,7 @@ function handle_drop(event)
 		const img = items[drag_id];
 		if(!img) return;
 
-		if(!is_valid_mode(drag_id, drag_mode)) return;
+		if(!is_valid_mode(drag_id, drag_mode, img.gbtype)) return;
 
 		if(drag_placeholder_div)
 		{

--- a/js/spark.js
+++ b/js/spark.js
@@ -316,6 +316,8 @@ function init_drag_and_drop()
 	for(let i = 0; i < sections.length; ++i)
 	{
 		sections[i].addEventListener("dragover", handle_dragover);
+		sections[i].addEventListener("dragenter", handle_dragenter);
+		sections[i].addEventListener("dragleave", handle_dragleave);
 		sections[i].addEventListener("drop", handle_drop);
 	}
 }
@@ -367,6 +369,22 @@ function handle_dragover(event)
 	}
 }
 
+function handle_dragenter(event)
+{
+	if(!is_valid_drag_event(event)) return;
+	if(event.currentTarget.contains(event.relatedTarget)) return;
+	const section = event.target.closest(".spark-section");
+	section.classList.add("spark-section-highlight");
+}
+
+function handle_dragleave(event)
+{
+	if(!is_valid_drag_event(event)) return;
+	if(event.currentTarget.contains(event.relatedTarget)) return;
+	const section = event.target.closest(".spark-section");
+	section.classList.remove("spark-section-highlight");
+}
+
 function handle_drop(event)
 {
 	if(!is_valid_drag_event(event)) return;
@@ -377,6 +395,7 @@ function handle_drop(event)
 	else
 	{
 		const section = event.target.closest(".spark-section");
+		section.classList.remove("spark-section-highlight");
 		let mode;
 		switch(section.id)
 		{

--- a/js/spark.js
+++ b/js/spark.js
@@ -220,7 +220,7 @@ function add_image_spark(node, data) // add an image to the selector
 	return img;
 }
 
-function add_image_result_spark(mode, id, base_img) // add image to the spark result
+function add_image_result_spark(mode, id, base_img, position) // add image to the spark result
 {
 	let node;
 	switch(mode)
@@ -271,8 +271,11 @@ function add_image_result_spark(mode, id, base_img) // add image to the spark re
 	img.src = base_img.src;
 	img.onerror = base_img.onerror;
 	div.appendChild(img);
-	node.appendChild(div);
-	lists[mode].push([id, div]);
+
+	if(position === undefined) position = lists[mode].length;
+	node.insertBefore(div, node.children[position]);
+	lists[mode].splice(position, 0, [id, div]);
+
 	update_node(mode, true);
 	return div;
 }

--- a/js/spark.js
+++ b/js/spark.js
@@ -228,6 +228,7 @@ function add_image_result_spark(mode, id, base_img) // add image to the spark re
 	}
 	let div = document.createElement("div");
 	div.classList.add("spark-result");
+	div.draggable = true;
 	const cmode = mode;
 	div.onclick = function()
 	{
@@ -260,6 +261,7 @@ function add_image_result_spark(mode, id, base_img) // add image to the spark re
 		}
 	};
 	let img = document.createElement("img");
+	img.draggable = false;
 	img.classList.add("spark-result-img");
 	img.src = base_img.src;
 	img.onerror = base_img.onerror;
@@ -282,6 +284,7 @@ function add_spark(div) // add spark icon
 	let img = document.createElement("img");
 	img.classList.add("spark-icon");
 	img.src = "assets/spark/spark.png";
+	img.draggable = false;
 	div.appendChild(img);
 	div.classList.add("sparked");
 }

--- a/js/spark.js
+++ b/js/spark.js
@@ -120,11 +120,10 @@ function is_summon(cid)
 
 function is_valid_mode(cid, mode, gbtype)
 {
-	if(gbtype == GBFType.summon && mode != STONE)
-		return false;
-	if(gbtype != GBFType.summon && mode == STONE)
-		return false;
-	return true;
+	return (
+		(gbtype == GBFType.summon && mode == STONE) ||
+		(gbtype != GBFType.summon && mode != STONE)
+	);
 }
 
 function set_spark_list()

--- a/js/spark.js
+++ b/js/spark.js
@@ -290,13 +290,13 @@ function add_image_result_spark(mode, id, base_img, position) // add image to th
 
 function toggle_spark_state(div) // toggle spark icon
 {
-	if(div.childNodes.length == 2) remove_spark(div);
-	else if(div.childNodes.length == 1) add_spark(div);
+	if(div.classList.contains("sparked")) remove_spark(div);
+	else add_spark(div);
 }
 
 function add_spark(div) // add spark icon
 {
-	if(div.childNodes.length == 2) return;
+	if(div.classList.contains("sparked")) return;
 	let img = document.createElement("img");
 	img.classList.add("spark-icon");
 	img.src = "assets/spark/spark.png";
@@ -307,7 +307,7 @@ function add_spark(div) // add spark icon
 
 function remove_spark(div) // remove spark icon
 {
-	if(div.childNodes.length != 2) return;
+	if(!div.classList.contains("sparked")) return;
 	div.removeChild(div.childNodes[1]);
 	div.classList.remove("sparked");
 }

--- a/js/spark.js
+++ b/js/spark.js
@@ -560,6 +560,16 @@ function update_all() // update all three columns
 	update_node(STONE, false);
 }
 
+function count_visible_nodes(list)
+{
+	let count = 0;
+	for(let i = 0; i < list.length; ++i)
+	{
+		if(list[i].style.display != "none") ++count;
+	}
+	return count;
+}
+
 function update_node(mode, addition) // update spark column
 {
 	let node;
@@ -586,11 +596,12 @@ function update_node(mode, addition) // update spark column
 		sizes[mode] = null;
 	}
 	let changed = false;
+	const visibleNodesCount = count_visible_nodes(node.childNodes);
 	while(true)
 	{
 		const cw = Math.floor(nw/current_size[0]); // number of element in a row inside the node
 		const ch = Math.floor(nh/current_size[1]) - 1; // number of element in a column inside the node (-1 to assure some space)
-		if(node.childNodes.length <= cw*ch) // if the total number of element is greater to our number of ssr
+		if(visibleNodesCount <= cw*ch) // if the total number of element is greater to our number of ssr
 		{
 			break;
 		}
@@ -638,8 +649,11 @@ function update_rate(to_update) // update ssr rate text
 			let s = 0; // sparked
 			for(let i = 0; i < COUNT; ++i)
 				for(let j = 0; j < lists[i].length; ++j)
-					if(lists[i][j][1].childNodes.length == 2) ++s;
-					else ++c;
+					if(lists[i][j][1].style.display != "none")
+					{
+						if(lists[i][j][1].childNodes.length == 2) ++s;
+						else ++c;
+					}
 			if(v < c) v = c;
 			document.getElementById("spark-rate").innerHTML = "" + c + " / " + v + (s > 0 ? " +" + s + " sparked": "") + "<br>" + (Math.round(c / v * 1000) / 10) + "% SSR";
 		}

--- a/js/spark.js
+++ b/js/spark.js
@@ -220,17 +220,20 @@ function add_image_spark(node, data) // add an image to the selector
 	return img;
 }
 
-function remove_image_result_spark(mode, div) // remove image from the spark result
+function remove_image_result_spark(div) // remove image from the spark result
 {
-	for(let i = 0; i < lists[mode].length; ++i) // look for it and remove
+	for(let mode = 0; mode < COUNT; ++mode)
 	{
-		if(div === lists[mode][i][1])
+		for(let i = 0; i < lists[mode].length; ++i) // look for it and remove
 		{
-			lists[mode].splice(i, 1);
+			if(div === lists[mode][i][1])
+			{
+				lists[mode].splice(i, 1);
+				div.remove();
+				update_node(mode, false);
+			}
 		}
 	}
-	div.remove();
-	update_node(mode, false);
 }
 
 function add_image_result_spark(mode, id, base_img, position) // add image to the spark result
@@ -265,7 +268,7 @@ function add_image_result_spark(mode, id, base_img, position) // add image to th
 			}
 			else
 			{
-				remove_image_result_spark(cmode, this);
+				remove_image_result_spark(this);
 			}
 			spark_save_settings();
 		}

--- a/js/spark.js
+++ b/js/spark.js
@@ -346,6 +346,7 @@ function init_drag_and_drop()
 {
 	// general drag events
 	document.addEventListener("pointerdown", handle_dragstart);
+	document.addEventListener("pointercancel", handle_dragend);
 }
 
 function find_target(base_target)
@@ -606,13 +607,16 @@ function handle_dragmove(event)
 {
 	if(!drag_state)
 		return;
+	if(event.cancelable)
+	{
+        event.preventDefault();
+    }
 	if(!(event.target instanceof HTMLElement))
 		return;
 	if(canvas_state > 0) // if canvas processing
 	{
 		return;
 	}
-	event.preventDefault();
 	queue_drag_state(event);
 }
 

--- a/js/spark.js
+++ b/js/spark.js
@@ -105,6 +105,11 @@ function default_onerror() // overwrite definition
 	this.remove();
 }
 
+function is_summon(cid)
+{
+	return cid.startsWith("20");
+}
+
 function set_spark_list()
 {
 	// for each characters
@@ -178,7 +183,7 @@ function add_image_spark(node, data) // add an image to the selector
 		};
 	}
 	else img.onerror = data.onerr;
-	const isSummon = data.id.startsWith("20");
+	const isSummon = is_summon(data.id);
 	const cid = data.id;
 	img.onload = function() {
 		this.classList.remove("loading");

--- a/js/spark.js
+++ b/js/spark.js
@@ -360,6 +360,11 @@ function handle_dragend(event)
 	if(!is_valid_drag_event(event)) return;
 	drag_id = null;
 	drag_is_spark = null;
+	const sections = document.querySelectorAll(".spark-section");
+	for(let i = 0; i < sections.length; ++i)
+	{
+		sections[i].classList.remove("spark-section-highlight");
+	}
 }
 
 function is_valid_drag_event(event)

--- a/js/spark.js
+++ b/js/spark.js
@@ -383,19 +383,23 @@ function handle_dragstart(event)
 		const section = target.closest(".spark-section");
 		if(section)
 		{
-			// store the neccesary info
-			drag_original_div = target;
-			drag_is_spark = target.classList.contains("sparked");
-			let mode;
-			switch(section.id)
+			// if ctrlKey is pressed, we make a new element instead
+			if(!event.ctrlKey)
 			{
-				case "spark-npc": mode = NPC; break;
-				case "spark-moon": mode = MOON; break;
-				case "spark-summon": mode = STONE; break;
-				default: return;
+				// store the neccesary info
+				drag_original_div = target;
+				drag_is_spark = target.classList.contains("sparked");
+				let mode;
+				switch(section.id)
+				{
+					case "spark-npc": mode = NPC; break;
+					case "spark-moon": mode = MOON; break;
+					case "spark-summon": mode = STONE; break;
+					default: return;
+				}
+				drag_mode = mode;
+				drag_position = Array.from(section.children).indexOf(drag_original_div);
 			}
-			drag_mode = mode;
-			drag_position = Array.from(section.children).indexOf(drag_original_div);
 			// the rest of the initializaion is done in update_drag_state()
 		}
 		else // the user is dragging from the select filter

--- a/js/spark.js
+++ b/js/spark.js
@@ -371,7 +371,7 @@ function handle_dragstart(event)
 	if(drag_state) // don't start if already on going
 		return;
 	const target = find_target(event.target);
-	if(target.spark_draggable !== true)
+	if(target.spark_draggable !== true || target.classList.contains("loading"))
 		return;
 	if(canvas_state > 0) // if canvas processing
 	{

--- a/js/spark.js
+++ b/js/spark.js
@@ -247,7 +247,7 @@ function remove_image_result_spark(div) // remove image from the spark result
 			{
 				lists[mode].splice(i, 1);
 				div.remove();
-				update_node(mode);
+				update_spark_result_size(mode);
 				return;
 			}
 		}
@@ -305,7 +305,7 @@ function add_image_result_spark(mode, id, base_img, position) // add image to th
 	node.insertBefore(div, node.children[position]);
 	lists[mode].splice(position, 0, [id, div]);
 
-	update_node(mode);
+	update_spark_result_size(mode);
 	return div;
 }
 
@@ -443,7 +443,7 @@ function handle_draginit(event)
 		if(drag_is_spark)
 			add_spark(drag_placeholder_div);
 		update_rate(false);
-		// note: No need for update_node()
+		// note: No need for update_spark_result_size()
 	}
 	// add the highlight
 	let drag_highlight_range = (
@@ -550,7 +550,7 @@ function update_drag_state(event)
 			lists[drag_mode].splice(drag_position, 1);
 			drag_placeholder_div.remove();
 			drag_placeholder_div = null;
-			update_node(drag_mode);
+			update_spark_result_size(drag_mode);
 			drag_mode = -1;
 			drag_position = -1;
 		}
@@ -572,7 +572,7 @@ function update_drag_state(event)
 		lists[drag_mode].splice(drag_position, 1);
 		drag_placeholder_div.remove();
 		drag_placeholder_div = null;
-		update_node(drag_mode);
+		update_spark_result_size(drag_mode);
 	}
 	// update mode and position
 	drag_mode = mode;
@@ -582,7 +582,7 @@ function update_drag_state(event)
 	drag_placeholder_div.classList.add("placeholder");
 	if(drag_is_spark)
 		add_spark(drag_placeholder_div);
-	update_node(drag_mode);
+	update_spark_result_size(drag_mode);
 	update_rate(false);
 }
 
@@ -706,9 +706,9 @@ function update_all() // update all three columns
 {
 	clearTimeout(resize_timer);
 	resize_timer = null;
-	update_node(NPC);
-	update_node(MOON);
-	update_node(STONE);
+	update_spark_result_size(NPC);
+	update_spark_result_size(MOON);
+	update_spark_result_size(STONE);
 }
 
 function count_visible_nodes(list)
@@ -721,7 +721,7 @@ function count_visible_nodes(list)
 	return count;
 }
 
-function update_node(mode) // update spark column
+function update_spark_result_size(mode) // update spark column
 {
 	let node;
 	switch(mode)

--- a/js/spark.js
+++ b/js/spark.js
@@ -498,6 +498,16 @@ function update_drag_state(event)
 						add_spark(drag_placeholder_div);
 					update_rate(false);
 				}
+				// add the highlight
+				let drag_highlight_range = (
+					items[drag_id].gbtype == GBFType.summon ?
+					[2, 3] :
+					[0, 2]
+				);
+				for(let i = drag_highlight_range[0]; i < drag_highlight_range[1]; ++i)
+				{
+					spark_sections[i].classList.toggle("spark-section-highlight", true);
+				}
 			}
 			else return;
 		}
@@ -535,10 +545,10 @@ function update_drag_state(event)
 		section = null;
 	if(section == null)
 	{
-		// if not, remove hightlight and placeholder
+		// if not, remove highlight and placeholder
 		for(const s of spark_sections)
 		{
-			s.classList.toggle("spark-section-highlight", false);
+			s.classList.toggle("spark-section-highlight-enabled", false);
 		}
 		if(drag_placeholder_div)
 		{
@@ -558,7 +568,7 @@ function update_drag_state(event)
 	// add the highlight
 	for(const s of spark_sections)
 	{
-		s.classList.toggle("spark-section-highlight", s == section);
+		s.classList.toggle("spark-section-highlight-enabled", s == section);
 	}
 	// remove previous placeholder
 	if(drag_placeholder_div)
@@ -658,7 +668,8 @@ function handle_dragend(event)
 	drag_position = null;
 	for(let i = 0; i < spark_sections.length; ++i)
 	{
-		spark_sections[i].classList.remove("spark-section-highlight");
+		spark_sections[i].classList.toggle("spark-section-highlight", false);
+		spark_sections[i].classList.toggle("spark-section-highlight-enabled", false);
 	}
 	// update and save
 	update_all();

--- a/js/spark.js
+++ b/js/spark.js
@@ -640,7 +640,6 @@ function handle_dragend(event, allow_beep = true)
 			if(is_valid_mode(drag_id, drag_mode, img.gbtype))
 			{
 				const div = add_image_result_spark(drag_mode, drag_id, img, drag_position);
-				drag_position++; // for the deletion of the placeholder in handle_dragstop
 				if(drag_is_spark)
 				{
 					add_spark(div);
@@ -681,8 +680,7 @@ function handle_dragstop()
 	// remove placeholder
 	if(drag_placeholder_div)
 	{
-		lists[drag_mode].splice(drag_position, 1);
-		drag_placeholder_div.remove();
+		remove_image_result_spark(drag_placeholder_div);
 		drag_placeholder_div = null;
 	}
 	// reset everything else

--- a/js/spark.js
+++ b/js/spark.js
@@ -473,6 +473,8 @@ function find_position(section, event)
 
 function update_drag_state(event)
 {
+	if(!event.clientX && !event.clientY)
+		return;
 	const section = event.target.closest(".spark-section");
 	let mode;
 	switch(section.id)

--- a/js/spark.js
+++ b/js/spark.js
@@ -666,7 +666,6 @@ function handle_dragend(event, allow_beep = true)
 		beep();
 	handle_dragstop();
 	// update and save
-	update_all_spark_result_size();
 	update_rate(false);
 	spark_save_settings();
 }
@@ -700,6 +699,7 @@ function handle_dragstop()
 		spark_sections[i].classList.toggle("spark-section-highlight", false);
 		spark_sections[i].classList.toggle("spark-section-highlight-enabled", false);
 	}
+	update_all_spark_result_size();
 }
 
 function update_all_spark_result_size() // update all three columns

--- a/js/spark.js
+++ b/js/spark.js
@@ -6,7 +6,6 @@ var timestamp = Date.now();
 var index = null;
 var items = {};
 var lists = [[], [], []];
-var sizes = [null, null, null];
 var spark_container = null;
 var spark_sections = null;
 const NPC = 0;
@@ -22,6 +21,7 @@ var canvas = null; // contains last canvas
 var canvas_state = 0; // 0 = not running, 1 = running, 2 = error
 var canvas_wait = 0; // used to track pending loadings
 // drag and drop
+var drag_state = 0; // 0 = not running, 1 = drag check, 2 = running
 var drag_event = null; // contains the last event received to process
 var drag_original_div = null; // the div that the user clicked on when dragging
 var drag_placeholder_div = null; // placeholder div that is displayed to the user during drag-and-drop
@@ -31,7 +31,7 @@ var drag_mode = null; // the mode (NPC/MOON/STONE) of the currently dragged item
 var drag_position = null; // the position of the currently dragged item
 var drag_coords = {x:0, y:0}; // pointer coordinates
 var drag_is_complete = true; // whether the last drag event was completed successfully
-
+var drag_ghost = null; // container of a "ghost" of the dragged image
 
 var jukebox = null;
 
@@ -199,6 +199,8 @@ function add_image_spark(node, data, gbtype) // add an image to the selector
 	let img = document.createElement("img");
 	img.title = data.id;
 	img.dataset.id = data.id;
+	img.spark_draggable = true;
+	img.draggable = false; // important for event interaction
 	img.gbtype = gbtype;
 	img.classList.add("loading");
 	img.classList.add("spark-image");
@@ -211,7 +213,7 @@ function add_image_spark(node, data, gbtype) // add an image to the selector
 	}
 	else img.onerror = data.onerr;
 	const cid = data.id;
-	img.onload = function() {
+	img.onload = function(event) {
 		this.classList.remove("loading");
 		this.classList.add("clickable");
 		this.onclick = function()
@@ -252,7 +254,7 @@ function remove_image_result_spark(div) // remove image from the spark result
 			{
 				lists[mode].splice(i, 1);
 				div.remove();
-				update_node(mode, false);
+				update_node(mode);
 				return;
 			}
 		}
@@ -271,9 +273,9 @@ function add_image_result_spark(mode, id, base_img, position) // add image to th
 	}
 	let div = document.createElement("div");
 	div.dataset.id = id;
+	div.draggable = false;
+	div.spark_draggable = true;
 	div.classList.add("spark-result");
-	div.draggable = true;
-	const cmode = mode;
 	div.onclick = function()
 	{
 		if(canvas_state > 0) // if canvas processing
@@ -294,20 +296,23 @@ function add_image_result_spark(mode, id, base_img, position) // add image to th
 				remove_image_result_spark(this);
 			}
 			spark_save_settings();
+			
 		}
 	};
+	const cmode = mode;
 	let img = document.createElement("img");
-	img.draggable = false;
-	img.classList.add("spark-result");
+	img.draggable = false; // important  for event interaction
+	img.classList.add("spark-result-img");
 	img.src = base_img.src;
 	img.onerror = base_img.onerror;
 	div.appendChild(img);
 
-	if(position === undefined) position = lists[mode].length;
+	if(position === undefined)
+		position = lists[mode].length;
 	node.insertBefore(div, node.children[position]);
 	lists[mode].splice(position, 0, [id, div]);
 
-	update_node(mode, true);
+	update_node(mode);
 	return div;
 }
 
@@ -324,7 +329,6 @@ function add_spark(div) // add spark icon
 	let img = document.createElement("img");
 	img.classList.add("spark-icon");
 	img.src = "assets/spark/spark.png";
-	img.draggable = false;
 	div.appendChild(img);
 	div.classList.add("sparked");
 }
@@ -346,27 +350,30 @@ addEventListener("resize", (event) => { // capture window resize event and call 
 function init_drag_and_drop()
 {
 	// general drag events
-	addEventListener("dragstart", handle_dragstart);
-	addEventListener("dragend", handle_dragend);
-	// sections drag events
-	for(let i = 0; i < spark_sections.length; ++i)
-	{
-		spark_sections[i].addEventListener("dragover", handle_dragover);
-		spark_sections[i].addEventListener("dragenter", handle_dragenter);
-		spark_sections[i].addEventListener("dragleave", handle_dragleave);
-		spark_sections[i].addEventListener("drop", handle_drop);
-	}
+	document.addEventListener("pointerdown", handle_dragstart);
 }
 
-function is_draggable(element)
+function find_target(base_target)
 {
-	const classList = element.classList;
-	return (classList.contains("spark-image") && classList.contains("clickable")) || classList.contains("spark-result");
+	// for pointer events,
+	// event.target sometimes catch the underlying image
+	return (
+		base_target.classList.contains("spark-image") ?
+		base_target :
+		(
+			base_target.classList.contains("spark-result-img") ?
+			base_target.parentNode : // catch the parent div
+			base_target
+		)
+	);
 }
 
 function handle_dragstart(event)
 {
-	if(!is_draggable(event.target))
+	if(drag_state) // don't start if already on going
+		return;
+	const target = find_target(event.target);
+	if(target.spark_draggable !== true)
 		return;
 	if(canvas_state > 0) // if canvas processing
 	{
@@ -374,15 +381,17 @@ function handle_dragstart(event)
 	}
 	else
 	{
-		event.dataTransfer.setData("custom-drag-event", "");
-		event.dataTransfer.effectAllowed = "move";
-		const section = event.target.closest(".spark-section");
-		drag_is_complete = false;
-		drag_id = event.target.dataset.id;
-		if(section) // the user is dragging from one of the three spark result sections
+		// get and check id
+		drag_id = target.dataset.id;
+		if(!(drag_id in items))
+			return;
+		// check if the user is dragging from one of the three spark result sections
+		const section = target.closest(".spark-section");
+		if(section)
 		{
-			drag_original_div = event.target;
-			drag_is_spark = event.target.classList.contains("sparked");
+			// store the neccesary info
+			drag_original_div = target;
+			drag_is_spark = target.classList.contains("sparked");
 			let mode;
 			switch(section.id)
 			{
@@ -393,69 +402,25 @@ function handle_dragstart(event)
 			}
 			drag_mode = mode;
 			drag_position = Array.from(section.children).indexOf(drag_original_div);
-
-			const img = items[drag_id];
-			if(!img)
-				return;
-			// hide the element that's being dragged and create a placeholder in its place
-			setTimeout(function() {
-				// need to use setTimeout here because otherwise the dragged image isn't displayed correctly
-				drag_original_div.style.display = "none";
-				drag_placeholder_div = add_image_result_spark(mode, drag_id, img, drag_position);
-				drag_placeholder_div.classList.add("placeholder");
-				if(drag_is_spark)
-					add_spark(drag_placeholder_div);
-				update_rate(false);
-			}, 0);
+			// the rest of the initializaion is done in update_drag_state()
 		}
 		else // the user is dragging from the select filter
 		{
 			// do nothing
 		}
+		// set state
+		drag_state = 1;
+		drag_is_complete = false;
+		drag_coords.x = event.clientX;
+		drag_coords.y = event.clientY;
+		drag_ghost = null;
+		// enable listeners
+		document.addEventListener("pointermove", handle_dragmove);
+		document.addEventListener("pointerup", handle_dragend);
 	}
 }
 
-function handle_dragend(event)
-{
-	if(!is_valid_drag_event(event))
-		return;
-	if(drag_placeholder_div)
-	{
-		lists[drag_mode].splice(drag_position, 1);
-		drag_placeholder_div.remove();
-		drag_placeholder_div = null;
-	}
-	if(drag_original_div)
-	{
-		if(drag_is_complete)
-		{
-			remove_image_result_spark(drag_original_div);
-		}
-		else
-		{
-			drag_original_div.style.display = null;
-			update_rate(false);
-		}
-		spark_save_settings();
-	}
-	drag_coords = {x:0, y:0};
-	drag_original_div = null;
-	drag_placeholder_div = null;
-	drag_id = null;
-	drag_is_spark = null;
-	drag_mode = null;
-	drag_position = null;
-	for(let i = 0; i < spark_sections.length; ++i)
-	{
-		spark_sections[i].classList.remove("spark-section-highlight");
-	}
-}
-
-function is_valid_drag_event(event)
-{
-	return event.dataTransfer.types.includes("custom-drag-event");
-}
-
+// find position in index from pointer coordinate
 function find_position(section, event)
 {
 	const children = section.children;
@@ -472,13 +437,27 @@ function find_position(section, event)
 	return position;
 }
 
+// return the section we're hovering, or null
+function find_section(event)
+{
+	if(drag_ghost)
+		drag_ghost.style.display = 'none';
+    const targetBelow = document.elementFromPoint(event.clientX, event.clientY);
+	if(drag_ghost)
+		drag_ghost.style.display = null;
+    if(!targetBelow)
+		return null;
+    return targetBelow.closest(".spark-section");
+}
+
+// queue an event for processing
 function queue_drag_state(event)
 {
 	const event_pending = drag_event != null;
 	drag_event = event;
 	if(!event_pending)
 	{
-		// only process the last event at the next frame
+		// only process the last received event at the next frame
 		requestAnimationFrame(() => {
 			const ev = drag_event;
 			drag_event = null;
@@ -490,56 +469,126 @@ function queue_drag_state(event)
 	}
 }
 
+// processing the event
 function update_drag_state(event)
 {
+	switch(drag_state)
+	{
+		case 1: // drag initialization
+		{
+			// check how much we moved since click down
+			const delta = {
+				x: event.clientX - drag_coords.x,
+				y: event.clientY == drag_coords.y
+			};
+			// check for accidental drags
+			// by looking for a movement of more than 5px
+			if(delta.x * delta.x + delta.y * delta.y > 25)
+			{
+				// initialize dragging
+				drag_state = 2;
+				// create ghost
+				// don't clone, in case the img isn't loaded
+				drag_ghost = document.createElement("img");
+				drag_ghost.src = items[drag_id].src;
+				drag_ghost.classList.add("spark-drag-ghost");
+				document.body.appendChild(drag_ghost);
+				// hide initial div and create placeholder
+				if(drag_original_div)
+				{
+					const img = items[drag_id];
+					drag_original_div.style.display = "none";
+					drag_placeholder_div = add_image_result_spark(drag_mode, drag_id, img, drag_position);
+					drag_placeholder_div.classList.add("placeholder");
+					if(drag_is_spark)
+						add_spark(drag_placeholder_div);
+					update_rate(false);
+				}
+			}
+			else return;
+		}
+		case 0: // not dragging
+		{
+			return;
+		}
+	}
 	if(!event.clientX && !event.clientY)
 		return;
 	// only update if moved
 	if(event.clientX == drag_coords.x && event.clientY == drag_coords.y)
 		return;
+	// update coordinates
 	drag_coords.x = event.clientX;
 	drag_coords.y = event.clientY;
-	
-	const section = event.target.closest(".spark-section");
+	if(drag_ghost) // use gpu via translate to avoid layout recalcul
+		drag_ghost.style.transform = `translate(${drag_coords.x - 52}px, ${drag_coords.y - 30}px)`;
+	const target = find_target(event.target);
+	let section = find_section(event);
+	const img = items[drag_id];
 	let mode;
-	switch(section.id)
+	if(section)
 	{
-		case "spark-npc": mode = NPC; break;
-		case "spark-moon": mode = MOON; break;
-		case "spark-summon": mode = STONE; break;
-		default: return;
+		switch(section.id)
+		{
+			case "spark-npc": mode = NPC; break;
+			case "spark-moon": mode = MOON; break;
+			case "spark-summon": mode = STONE; break;
+			default: return;
+		}
 	}
+	// check if the targeted section is valid
+	if(!img || !is_valid_mode(drag_id, mode, img.gbtype))
+		section = null;
+	if(section == null)
+	{
+		// if not, remove hightlight and placeholder
+		for(const s of spark_sections)
+		{
+			s.classList.toggle("spark-section-highlight", false);
+		}
+		if(drag_placeholder_div)
+		{
+			lists[drag_mode].splice(drag_position, 1);
+			drag_placeholder_div.remove();
+			drag_placeholder_div = null;
+			drag_mode = -1;
+			drag_position = -1;
+		}
+		return;
+	}
+	// find position
 	const position = find_position(section, event);
+	// and check if it changed
 	if(drag_mode === mode && drag_position === position)
 		return;
+	// add the highlight
 	for(const s of spark_sections)
 	{
 		s.classList.toggle("spark-section-highlight", s == section);
 	}
+	// remove previous placeholder
 	if(drag_placeholder_div)
 	{
 		lists[drag_mode].splice(drag_position, 1);
 		drag_placeholder_div.remove();
 		drag_placeholder_div = null;
 	}
+	// update mode and position
 	drag_mode = mode;
 	drag_position = position;
-	if(is_valid_mode(drag_id, mode, items[drag_id].gbtype))
-	{
-		const img = items[drag_id];
-		if(!img)
-			return;
-		drag_placeholder_div = add_image_result_spark(mode, drag_id, img, drag_position);
-		drag_placeholder_div.classList.add("placeholder");
-		if(drag_is_spark)
-			add_spark(drag_placeholder_div);
-		update_rate(false);
-	}
+	// set new placeholder
+	drag_placeholder_div = add_image_result_spark(mode, drag_id, img, drag_position);
+	drag_placeholder_div.classList.add("placeholder");
+	if(drag_is_spark)
+		add_spark(drag_placeholder_div);
+	update_node(mode);
+	update_rate(false);
 }
 
-function handle_dragover(event)
+// triggered when moving the mouse
+function handle_dragmove(event)
 {
-	if(!is_valid_drag_event(event))
+	if(!drag_state)
 		return;
 	if(canvas_state > 0) // if canvas processing
 	{
@@ -549,75 +598,86 @@ function handle_dragover(event)
 	queue_drag_state(event);
 }
 
-function handle_dragenter(event)
+// triggered when releasing the mouse
+function handle_dragend(event)
 {
-	if(!is_valid_drag_event(event))
+	if(drag_state == 0)
 		return;
-	if(event.currentTarget.contains(event.relatedTarget))
-		return;
-	queue_drag_state(event);
-}
-
-function handle_dragleave(event)
-{
-	if(!is_valid_drag_event(event))
-		return;
-	if(event.currentTarget.contains(event.relatedTarget))
-		return;
-	queue_drag_state(event);
-}
-
-function handle_drop(event)
-{
-	if(!is_valid_drag_event(event))
-		return;
-	if(canvas_state > 0) // if canvas processing
+	if(drag_ghost)
+		drag_ghost.remove();
+	// flag to check if we dragging went through
+	const process_drag = canvas_state == 0 && drag_state == 2;
+	// remove listeners
+	document.removeEventListener("pointermove", handle_dragmove);
+	document.removeEventListener("pointerup", handle_dragend);
+	if(process_drag && drag_mode != -1)
 	{
-		push_popup("Wait for the image to be processed");
-	}
-	else
-	{
-		// force process last event
-		if(drag_event != null)
-		{
-			const ev = drag_event;
-			drag_event = null;
-			update_drag_state(ev);
-		}
-		const section = event.target.closest(".spark-section");
-		section.classList.remove("spark-section-highlight");
-		queue_drag_state(event);
+		// force process the queued last event
+		drag_event = null;
+		update_drag_state(event);
 		const img = items[drag_id];
-		if(!img)
-			return;
-
-		if(!is_valid_mode(drag_id, drag_mode, img.gbtype))
-			return;
-
-		if(drag_placeholder_div)
+		if(img)
 		{
-			lists[drag_mode].splice(drag_position, 1);
-			drag_placeholder_div.remove();
-			drag_placeholder_div = null;
+			// check validity and add to list
+			if(is_valid_mode(drag_id, drag_mode, img.gbtype))
+			{
+				const div = add_image_result_spark(drag_mode, drag_id, img, drag_position);
+				if(drag_is_spark)
+				{
+					add_spark(div);
+				}
+				drag_is_complete = true;
+			}
 		}
-
-		beep();
-		const div = add_image_result_spark(drag_mode, drag_id, img, drag_position);
-		if(drag_is_spark)
-			add_spark(div);
-		update_rate(false);
-		spark_save_settings();
-		drag_is_complete = true;
 	}
+	// remove placeholder
+	if(drag_placeholder_div)
+	{
+		lists[drag_mode].splice(drag_position, 1);
+		drag_placeholder_div.remove();
+		drag_placeholder_div = null;
+	}
+	// remove or restore original div
+	if(drag_original_div)
+	{
+		if(drag_is_complete || drag_mode == -1)
+		{
+			remove_image_result_spark(drag_original_div);
+			drag_is_complete = true; // for the beep below
+		}
+		else
+		{
+			drag_original_div.style.display = null;
+		}
+	}
+	if(drag_is_complete)
+		beep();
+	// reset everything else
+	drag_state = 0;
+	drag_coords = {x:0, y:0};
+	drag_original_div = null;
+	drag_placeholder_div = null;
+	drag_id = null;
+	drag_is_spark = null;
+	drag_mode = null;
+	drag_position = null;
+	for(let i = 0; i < spark_sections.length; ++i)
+	{
+		spark_sections[i].classList.remove("spark-section-highlight");
+	}
+	// update and save
+	update_all();
+	update_rate(false);
+	spark_save_settings();
 }
 
 function update_all() // update all three columns
 {
 	clearTimeout(resize_timer);
 	resize_timer = null;
-	update_node(NPC, false);
-	update_node(MOON, false);
-	update_node(STONE, false);
+	update_node(NPC);
+	update_node(MOON);
+	update_node(STONE);
 }
 
 function count_visible_nodes(list)
@@ -630,7 +690,7 @@ function count_visible_nodes(list)
 	return count;
 }
 
-function update_node(mode, addition) // update spark column
+function update_node(mode) // update spark column
 {
 	let node;
 	switch(mode)
@@ -646,16 +706,7 @@ function update_node(mode, addition) // update spark column
 	// get node size
 	const nw = node.offsetWidth - 5;
 	const nh = node.offsetHeight - 5;
-	let current_size;
-	if(addition) // get last size if we just added a new element
-	{
-		current_size = sizes[mode];
-	}
-	if(current_size == null)
-	{
-		current_size = DEFAULT_SIZE; // get default size otherwise
-		sizes[mode] = null;
-	}
+	let current_size = DEFAULT_SIZE; // get default size otherwise
 	let changed = false;
 	const visibleNodesCount = count_visible_nodes(node.childNodes);
 	while(true)
@@ -666,15 +717,18 @@ function update_node(mode, addition) // update spark column
 		{
 			break;
 		}
-		sizes[mode] = [current_size[0]*0.9, current_size[1]*0.9]; // else, reduce size by 10% and try again
-		current_size = sizes[mode];
+		// else, reduce size by 10% and try again
+		current_size = [
+			current_size[0] * 0.9,
+			current_size[1] * 0.9
+		];
 		changed = true;
 	}
 	if(changed) // if size changed
 	{
 		for(let i = 0; i < node.childNodes.length; ++i) // resize all elements
 		{
-			if(sizes[mode] == null)
+			if(current_size == null)
 			{
 				node.childNodes[i].style.minWidth = null;
 				node.childNodes[i].style.minHeight = null;
@@ -683,10 +737,10 @@ function update_node(mode, addition) // update spark column
 			}
 			else
 			{
-				node.childNodes[i].style.minWidth = "" + Math.max(1, sizes[mode][0]) + "px"; // min needed for mobile
-				node.childNodes[i].style.minHeight = "" + Math.max(1, sizes[mode][1]) + "px";
-				node.childNodes[i].style.maxWidth = "" + Math.max(1, sizes[mode][0]) + "px";
-				node.childNodes[i].style.maxHeight = "" + Math.max(1, sizes[mode][1]) + "px";
+				node.childNodes[i].style.minWidth = "" + Math.max(1, current_size[0]) + "px"; // min needed for mobile
+				node.childNodes[i].style.minHeight = "" + Math.max(1, current_size[1]) + "px";
+				node.childNodes[i].style.maxWidth = "" + Math.max(1, current_size[0]) + "px";
+				node.childNodes[i].style.maxHeight = "" + Math.max(1, current_size[1]) + "px";
 			}
 		}
 	}

--- a/js/spark.js
+++ b/js/spark.js
@@ -12,7 +12,6 @@ const NPC = 0;
 const MOON = 1;
 const STONE = 2;
 const COUNT = 3;
-const HEIGHT = 50;
 const DEFAULT_SIZE = [140, 80];
 var resize_timer = null;
 // image generation
@@ -119,11 +118,6 @@ function open_spark_tab(tabName) // reset and then select a tab
 function default_onerror() // overwrite definition
 {
 	this.remove();
-}
-
-function is_summon(cid)
-{
-	return cid.startsWith("20");
 }
 
 function is_valid_mode(cid, mode, gbtype)
@@ -479,7 +473,7 @@ function update_drag_state(event)
 			// check how much we moved since click down
 			const delta = {
 				x: event.clientX - drag_coords.x,
-				y: event.clientY == drag_coords.y
+				y: event.clientY - drag_coords.y
 			};
 			// check for accidental drags
 			// by looking for a movement of more than 5px

--- a/js/spark.js
+++ b/js/spark.js
@@ -490,6 +490,7 @@ function update_drag_state(event)
 				drag_ghost = document.createElement("img");
 				drag_ghost.src = items[drag_id].src;
 				drag_ghost.classList.add("spark-drag-ghost");
+				drag_ghost.style.transform = `translate(${event.clientX - 52}px, ${event.clientY - 30}px)`;
 				document.body.appendChild(drag_ghost);
 				// hide initial div and create placeholder
 				if(drag_original_div)

--- a/js/spark.js
+++ b/js/spark.js
@@ -322,6 +322,7 @@ function add_spark(div) // add spark icon
 		return;
 	let img = document.createElement("img");
 	img.classList.add("spark-icon");
+	img.draggable = false;
 	img.src = "assets/spark/spark.png";
 	div.appendChild(img);
 	div.classList.add("sparked");
@@ -355,7 +356,10 @@ function find_target(base_target)
 		base_target.classList.contains("spark-image") ?
 		base_target :
 		(
-			base_target.classList.contains("spark-result-img") ?
+			(
+				base_target.classList.contains("spark-result-img") ||
+				base_target.classList.contains("spark-icon")
+			) ?
 			base_target.parentNode : // catch the parent div
 			base_target
 		)

--- a/js/spark.js
+++ b/js/spark.js
@@ -193,7 +193,6 @@ function add_image_spark(node, data, gbtype) // add an image to the selector
 	let img = document.createElement("img");
 	img.title = data.id;
 	img.dataset.id = data.id;
-	img.spark_draggable = true;
 	img.draggable = false; // important for event interaction
 	img.gbtype = gbtype;
 	img.classList.add("loading");
@@ -354,16 +353,12 @@ function find_target(base_target)
 	// for pointer events,
 	// event.target sometimes catch the underlying image
 	return (
-		base_target.classList.contains("spark-image") ?
-		base_target :
 		(
-			(
-				base_target.classList.contains("spark-result-img") ||
-				base_target.classList.contains("spark-icon")
-			) ?
-			base_target.parentNode : // catch the parent div
-			base_target
-		)
+			base_target.classList.contains("spark-result-img") ||
+			base_target.classList.contains("spark-icon")
+		) ?
+		base_target.parentNode : // catch the parent div
+		base_target
 	);
 }
 

--- a/js/spark.js
+++ b/js/spark.js
@@ -318,18 +318,27 @@ addEventListener("resize", (event) => { // capture window resize event and call 
 	resize_timer = setTimeout(update_all, 300);
 });
 
-function init_drag_and_drop()
+function init_drag()
 {
 	addEventListener("dragstart", handle_dragstart);
 	addEventListener("dragend", handle_dragend);
+}
 
+function init_drop(element)
+{
+	element.addEventListener("dragover", handle_dragover);
+	element.addEventListener("dragenter", handle_dragenter);
+	element.addEventListener("dragleave", handle_dragleave);
+	element.addEventListener("drop", handle_drop);
+}
+
+function init_drag_and_drop()
+{
+	init_drag();
 	const sections = document.querySelectorAll(".spark-section");
 	for(let i = 0; i < sections.length; ++i)
 	{
-		sections[i].addEventListener("dragover", handle_dragover);
-		sections[i].addEventListener("dragenter", handle_dragenter);
-		sections[i].addEventListener("dragleave", handle_dragleave);
-		sections[i].addEventListener("drop", handle_drop);
+		init_drop(sections[i]);
 	}
 }
 

--- a/js/spark.js
+++ b/js/spark.js
@@ -616,6 +616,7 @@ function handle_dragend(event)
 		return;
 	if(drag_ghost)
 		drag_ghost.remove();
+	drag_ghost = null;
 	// flag to check if we dragging went through
 	const process_drag = canvas_state == 0 && drag_state == 2;
 	// remove listeners

--- a/js/spark.js
+++ b/js/spark.js
@@ -616,6 +616,7 @@ function handle_dragend(event)
 			if(is_valid_mode(drag_id, drag_mode, img.gbtype))
 			{
 				const div = add_image_result_spark(drag_mode, drag_id, img, drag_position);
+				drag_position++; // for the deletion of the placeholder
 				if(drag_is_spark)
 				{
 					add_spark(div);

--- a/js/spark.js
+++ b/js/spark.js
@@ -346,7 +346,7 @@ function init_drag_and_drop()
 {
 	// general drag events
 	document.addEventListener("pointerdown", handle_dragstart);
-	document.addEventListener("pointercancel", handle_dragend);
+	document.addEventListener("pointercancel", (event) => {handle_dragend(event, false)});
 }
 
 function find_target(base_target)
@@ -621,7 +621,7 @@ function handle_dragmove(event)
 }
 
 // triggered when releasing the mouse
-function handle_dragend(event)
+function handle_dragend(event, allow_beep = true)
 {
 	if(drag_state == 0)
 		return;
@@ -674,7 +674,7 @@ function handle_dragend(event)
 			drag_original_div.style.display = null;
 		}
 	}
-	if(drag_is_complete)
+	if(drag_is_complete && allow_beep)
 		beep();
 	// reset everything else
 	drag_state = 0;

--- a/js/spark.js
+++ b/js/spark.js
@@ -173,6 +173,7 @@ function add_image_spark(node, data) // add an image to the selector
 {
 	let img = document.createElement("img");
 	img.title = data.id;
+	img.dataset.id = data.id;
 	img.classList.add("loading");
 	img.classList.add("spark-image");
 	img.setAttribute('loading', 'lazy');
@@ -227,6 +228,7 @@ function add_image_result_spark(mode, id, base_img) // add image to the spark re
 		default: return;
 	}
 	let div = document.createElement("div");
+	div.dataset.id = id;
 	div.classList.add("spark-result");
 	div.draggable = true;
 	const cmode = mode;

--- a/js/spark.js
+++ b/js/spark.js
@@ -335,10 +335,10 @@ function remove_spark(div) // remove spark icon
 	div.classList.remove("sparked");
 }
 
-addEventListener("resize", (event) => { // capture window resize event and call update_all() (after 300ms)
+addEventListener("resize", (event) => { // capture window resize event and call update_all_spark_result_size() (after 300ms)
 	if(resize_timer != null)
 		clearTimeout(resize_timer);
-	resize_timer = setTimeout(update_all, 300);
+	resize_timer = setTimeout(update_all_spark_result_size, 300);
 });
 
 function init_drag_and_drop()
@@ -666,7 +666,7 @@ function handle_dragend(event, allow_beep = true)
 		beep();
 	handle_dragstop();
 	// update and save
-	update_all();
+	update_all_spark_result_size();
 	update_rate(false);
 	spark_save_settings();
 }
@@ -702,7 +702,7 @@ function handle_dragstop()
 	}
 }
 
-function update_all() // update all three columns
+function update_all_spark_result_size() // update all three columns
 {
 	clearTimeout(resize_timer);
 	resize_timer = null;
@@ -845,7 +845,7 @@ function spark_clear() // clear everything
 		node.innerHTML = "";
 	}
 	document.getElementById("spark-roll-input").value = 300;
-	update_all();
+	update_all_spark_result_size();
 	update_rate(false);
 }
 

--- a/js/spark.js
+++ b/js/spark.js
@@ -501,6 +501,7 @@ function update_drag_state(event)
 					if(drag_is_spark)
 						add_spark(drag_placeholder_div);
 					update_rate(false);
+					// note: No need for update_node()
 				}
 				// add the highlight
 				let drag_highlight_range = (
@@ -559,6 +560,7 @@ function update_drag_state(event)
 			lists[drag_mode].splice(drag_position, 1);
 			drag_placeholder_div.remove();
 			drag_placeholder_div = null;
+			update_node(drag_mode);
 			drag_mode = -1;
 			drag_position = -1;
 		}
@@ -580,6 +582,7 @@ function update_drag_state(event)
 		lists[drag_mode].splice(drag_position, 1);
 		drag_placeholder_div.remove();
 		drag_placeholder_div = null;
+		update_node(drag_mode);
 	}
 	// update mode and position
 	drag_mode = mode;
@@ -589,7 +592,7 @@ function update_drag_state(event)
 	drag_placeholder_div.classList.add("placeholder");
 	if(drag_is_spark)
 		add_spark(drag_placeholder_div);
-	update_node(mode);
+	update_node(drag_mode);
 	update_rate(false);
 }
 

--- a/js/spark.js
+++ b/js/spark.js
@@ -120,8 +120,10 @@ function is_summon(cid)
 
 function is_valid_mode(cid, mode, gbtype)
 {
-	if(gbtype == GBFType.summon && mode != STONE) return false;
-	if(gbtype != GBFType.summon && mode == STONE) return false;
+	if(gbtype == GBFType.summon && mode != STONE)
+		return false;
+	if(gbtype != GBFType.summon && mode == STONE)
+		return false;
 	return true;
 }
 
@@ -308,7 +310,8 @@ function toggle_spark_state(div) // toggle spark icon
 
 function add_spark(div) // add spark icon
 {
-	if(div.classList.contains("sparked")) return;
+	if(div.classList.contains("sparked"))
+		return;
 	let img = document.createElement("img");
 	img.classList.add("spark-icon");
 	img.src = "assets/spark/spark.png";
@@ -319,7 +322,8 @@ function add_spark(div) // add spark icon
 
 function remove_spark(div) // remove spark icon
 {
-	if(!div.classList.contains("sparked")) return;
+	if(!div.classList.contains("sparked"))
+		return;
 	div.removeChild(div.childNodes[1]);
 	div.classList.remove("sparked");
 }
@@ -362,7 +366,8 @@ function is_draggable(element)
 
 function handle_dragstart(event)
 {
-	if(!is_draggable(event.target)) return;
+	if(!is_draggable(event.target))
+		return;
 	if(canvas_state > 0) // if canvas processing
 	{
 		push_popup("Wait for the image to be processed");
@@ -390,7 +395,8 @@ function handle_dragstart(event)
 			drag_position = Array.from(section.children).indexOf(drag_original_div);
 
 			const img = items[drag_id];
-			if(!img) return;
+			if(!img)
+				return;
 			// hide the element that's being dragged and create a placeholder in its place
 			setTimeout(function() {
 				// need to use setTimeout here because otherwise the dragged image isn't displayed correctly
@@ -411,7 +417,8 @@ function handle_dragstart(event)
 
 function handle_dragend(event)
 {
-	if(!is_valid_drag_event(event)) return;
+	if(!is_valid_drag_event(event))
+		return;
 	if(drag_placeholder_div)
 	{
 		remove_image_result_spark(drag_placeholder_div);
@@ -476,7 +483,8 @@ function update_drag_state(event)
 		default: return;
 	}
 	const position = find_position(section, event);
-	if(drag_mode === mode && drag_position === position) return;
+	if(drag_mode === mode && drag_position === position)
+		return;
 	drag_mode = mode;
 	drag_position = position;
 	if(drag_placeholder_div)
@@ -487,7 +495,8 @@ function update_drag_state(event)
 	if(is_valid_mode(drag_id, mode, items[drag_id].gbtype))
 	{
 		const img = items[drag_id];
-		if(!img) return;
+		if(!img)
+			return;
 		drag_placeholder_div = add_image_result_spark(mode, drag_id, img, drag_position);
 		drag_placeholder_div.classList.add("placeholder");
 		if(drag_is_spark)
@@ -498,7 +507,8 @@ function update_drag_state(event)
 
 function handle_dragover(event)
 {
-	if(!is_valid_drag_event(event)) return;
+	if(!is_valid_drag_event(event))
+		return;
 	if(canvas_state > 0) // if canvas processing
 	{
 		push_popup("Wait for the image to be processed");
@@ -512,8 +522,10 @@ function handle_dragover(event)
 
 function handle_dragenter(event)
 {
-	if(!is_valid_drag_event(event)) return;
-	if(event.currentTarget.contains(event.relatedTarget)) return;
+	if(!is_valid_drag_event(event))
+		return;
+	if(event.currentTarget.contains(event.relatedTarget))
+		return;
 	const section = event.target.closest(".spark-section");
 	section.classList.add("spark-section-highlight");
 	update_drag_state(event);
@@ -521,8 +533,10 @@ function handle_dragenter(event)
 
 function handle_dragleave(event)
 {
-	if(!is_valid_drag_event(event)) return;
-	if(event.currentTarget.contains(event.relatedTarget)) return;
+	if(!is_valid_drag_event(event))
+		return;
+	if(event.currentTarget.contains(event.relatedTarget))
+		return;
 	const section = event.target.closest(".spark-section");
 	section.classList.remove("spark-section-highlight");
 	update_drag_state(event);
@@ -530,7 +544,8 @@ function handle_dragleave(event)
 
 function handle_drop(event)
 {
-	if(!is_valid_drag_event(event)) return;
+	if(!is_valid_drag_event(event))
+		return;
 	if(canvas_state > 0) // if canvas processing
 	{
 		push_popup("Wait for the image to be processed");
@@ -543,7 +558,8 @@ function handle_drop(event)
 		const img = items[drag_id];
 		if(!img) return;
 
-		if(!is_valid_mode(drag_id, drag_mode, img.gbtype)) return;
+		if(!is_valid_mode(drag_id, drag_mode, img.gbtype))
+			return;
 
 		if(drag_placeholder_div)
 		{
@@ -591,7 +607,8 @@ function update_node(mode, addition) // update spark column
 		default: return;
 	}
 	update_rate(false); // update rate text
-	if(node.childNodes.length == 0) return; // quit if empty
+	if(node.childNodes.length == 0)
+		return; // quit if empty
 	// get node size
 	const nw = node.offsetWidth - 5;
 	const nh = node.offsetHeight - 5;
@@ -781,10 +798,13 @@ function load_settings() // load settings from localstorage
 	try
 	{
 		let tmp = localStorage.getItem("gbfal-spark-settings");
-		if(tmp == null) return;
+		if(tmp == null)
+			return;
 		tmp = JSON.parse(tmp);
-		if(tmp[0]) document.getElementById("moon-check").classList.add("active");
-		if(tmp[1]) document.getElementById("spark-check").classList.add("active");
+		if(tmp[0])
+			document.getElementById("moon-check").classList.add("active");
+		if(tmp[1])
+			document.getElementById("spark-check").classList.add("active");
 	}
 	catch(err)
 	{
@@ -959,7 +979,8 @@ function draw_spark(canvas) // draw the spark on the canvas
 
 function draw_spark_middle(ctx) // draw the spark content
 {
-	if(canvas_state == 2) return;
+	if(canvas_state == 2)
+		return;
 	if(canvas_wait > 1)
 	{
 		setTimeout(draw_spark_middle, 50, ctx);
@@ -979,7 +1000,8 @@ function draw_spark_middle(ctx) // draw the spark content
 
 function draw_spark_end(ctx, sparkIcon_list) // draw the spark icons
 {
-	if(canvas_state == 2) return;
+	if(canvas_state == 2)
+		return;
 	if(canvas_wait > 1)
 	{
 		setTimeout(draw_spark_end, 50, ctx, sparkIcon_list);
@@ -1018,7 +1040,8 @@ function draw_image(ctx, src, x, y, w, h) // draw an image at the specified src 
 function draw_column(ctx, offset, content)
 {
 	const imgcount = content.length;
-	if(imgcount == 0) return []; // if no image, stop now
+	if(imgcount == 0)
+		return []; // if no image, stop now
 	const RECT_CONTENT = [offset+50, 100+50+50, 640-100, 1080-200-50];
 	let size = [RECT_CONTENT[2], RECT_CONTENT[2]*DEFAULT_SIZE[1]/DEFAULT_SIZE[0]]; // default image size (make it fit the area horizontally, keeping the aspect ratio)
 	let grid = [0, 0]; // will contain the number of horizontal and vertical elements

--- a/js/spark.js
+++ b/js/spark.js
@@ -220,6 +220,19 @@ function add_image_spark(node, data) // add an image to the selector
 	return img;
 }
 
+function remove_image_result_spark(mode, div) // remove image from the spark result
+{
+	for(let i = 0; i < lists[mode].length; ++i) // look for it and remove
+	{
+		if(div === lists[mode][i][1])
+		{
+			lists[mode].splice(i, 1);
+		}
+	}
+	div.remove();
+	update_node(mode, false);
+}
+
 function add_image_result_spark(mode, id, base_img, position) // add image to the spark result
 {
 	let node;
@@ -252,15 +265,7 @@ function add_image_result_spark(mode, id, base_img, position) // add image to th
 			}
 			else
 			{
-				for(let i = 0; i < lists[cmode].length; ++i) // look for it and remove
-				{
-					if(this === lists[cmode][i][1])
-					{
-						lists[cmode].splice(i, 1);
-					}
-				}
-				this.remove();
-				update_node(cmode, false);
+				remove_image_result_spark(cmode, this);
 			}
 			spark_save_settings();
 		}

--- a/js/spark.js
+++ b/js/spark.js
@@ -601,6 +601,8 @@ function handle_dragmove(event)
 {
 	if(!drag_state)
 		return;
+	if(!(event.target instanceof HTMLElement))
+		return;
 	if(canvas_state > 0) // if canvas processing
 	{
 		return;

--- a/spark.html
+++ b/spark.html
@@ -36,7 +36,7 @@
 <body onload="init()">
 	<a href="index.html"><img id="title-header" src="assets/ui/header.png" alt="header"></a>
 	<div id="header">
-		<div>Spark v2.8</div>
+		<div>Spark v2.9</div>
 		<div id="timestamp"></div>
 	</div>
 	<!-- Know issues -->

--- a/spark.html
+++ b/spark.html
@@ -106,7 +106,9 @@
 			<li><b>Click</b> a Character or Summon to <b>add</b> it to the list.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-moon.png"></button> or <b>Hold Shift</b> before adding a Character to add it to the <b>Moon Column</b>.</li>
 			<li><b>Click</b> on an Element to <b>Remove</b> it from the list.</li>
-			<li>Or <b>Drag</b> Elements to add, remove or reorder them. <b>Ctrl+Click and Drag</b> on an added element to copy it.</li>
+			<li>Or <b>Drag</b> Elements to add, remove or reorder them.</li>
+			<li>On <b>PC</b>, <b>Ctrl+Click and Drag</b> on an added element to copy it.</li>
+			<li>On <b>Mobile</b>, start <b>sliding horizontally</b> on a bottom element before dragging it to the top. Otherwise you'll scroll the section.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-spark.png"></button> or <b>Hold Shift</b> and click on an Element to toggle its <img src="assets/spark/spark.png" class="spark-manual-icon"> Sparked state.</li>
 			<li>Change the <b>number of rolls</b> next to the Filter.</li>
 			<li><button class="spark-ui-element spark-ui-button"><img class="spark-btn-icon" src="assets/spark/btn-save.png"></button> to generate an <b>Image</b> of your spark. You can then right click/hold touch it, to Copy or Save as <b>(It might not work on some phones/browsers, please take a screenshot instead)</b>.</li>

--- a/spark.html
+++ b/spark.html
@@ -106,7 +106,7 @@
 			<li><b>Click</b> a Character or Summon to <b>add</b> it to the list.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-moon.png"></button> or <b>Hold Shift</b> before adding a Character to add it to the <b>Moon Column</b>.</li>
 			<li><b>Click</b> on an Element to <b>Remove</b> it from the list.</li>
-			<li><b>Drag</b> Elements to reorder them.</li>
+			<li>Or <b>Drag</b> Elements to add, remove or reorder them. <b>Ctrl+Click and Drag</b> on an added element to copy it.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-spark.png"></button> or <b>Hold Shift</b> and click on an Element to toggle its <img src="assets/spark/spark.png" class="spark-manual-icon"> Sparked state.</li>
 			<li>Change the <b>number of rolls</b> next to the Filter.</li>
 			<li><button class="spark-ui-element spark-ui-button"><img class="spark-btn-icon" src="assets/spark/btn-save.png"></button> to generate an <b>Image</b> of your spark. You can then right click/hold touch it, to Copy or Save as <b>(It might not work on some phones/browsers, please take a screenshot instead)</b>.</li>

--- a/spark.html
+++ b/spark.html
@@ -106,6 +106,7 @@
 			<li><b>Click</b> a Character or Summon to <b>add</b> it to the list.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-moon.png"></button> or <b>Hold Shift</b> before adding a Character to add it to the <b>Moon Column</b>.</li>
 			<li><b>Click</b> on an Element to <b>Remove</b> it from the list.</li>
+			<li><b>Drag</b> Elements to reorder them.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-spark.png"></button> or <b>Hold Shift</b> and click on an Element to toggle its <img src="assets/spark/spark.png" class="spark-manual-icon"> Sparked state.</li>
 			<li>Change the <b>number of rolls</b> next to the Filter.</li>
 			<li><button class="spark-ui-element spark-ui-button"><img class="spark-btn-icon" src="assets/spark/btn-save.png"></button> to generate an <b>Image</b> of your spark. You can then right click/hold touch it, to Copy or Save as <b>(It might not work on some phones/browsers, please take a screenshot instead)</b>.</li>

--- a/spark.html
+++ b/spark.html
@@ -106,9 +106,7 @@
 			<li><b>Click</b> a Character or Summon to <b>add</b> it to the list.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-moon.png"></button> or <b>Hold Shift</b> before adding a Character to add it to the <b>Moon Column</b>.</li>
 			<li><b>Click</b> on an Element to <b>Remove</b> it from the list.</li>
-			<li>Or <b>Drag</b> Elements to add, remove or reorder them.</li>
-			<li>On <b>PC</b>, <b>Ctrl+Click and Drag</b> on an added element to copy it.</li>
-			<li>On <b>Mobile</b>, start <b>sliding horizontally</b> on a bottom element before dragging it to the top. Otherwise you'll scroll the section.</li>
+			<li>Or <b>Drag</b> Elements to remove or reorder them. On <b>PC</b>, <b>Ctrl and Drag</b> to duplicate an element.</li>
 			<li><button class="spark-ui-element spark-ui-button active"><img class="spark-btn-icon" src="assets/spark/btn-spark.png"></button> or <b>Hold Shift</b> and click on an Element to toggle its <img src="assets/spark/spark.png" class="spark-manual-icon"> Sparked state.</li>
 			<li>Change the <b>number of rolls</b> next to the Filter.</li>
 			<li><button class="spark-ui-element spark-ui-button"><img class="spark-btn-icon" src="assets/spark/btn-save.png"></button> to generate an <b>Image</b> of your spark. You can then right click/hold touch it, to Copy or Save as <b>(It might not work on some phones/browsers, please take a screenshot instead)</b>.</li>


### PR DESCRIPTION
Hi, I've implemented support for dragging and dropping the characters and summons on the Spark Maker page. This includes:
1. Dragging a character or a summon from the search filter into the NPC/Moon/Stone section.
2. Dragging characters between the NPC and Moon sections.
3. Reordering characters or summons within a section.

Here's a video of how it works:

https://github.com/user-attachments/assets/e0320fdf-5590-413b-bcf0-3430069d9f7d

Please let me know if this looks OK.

Thanks!